### PR TITLE
Adds an overload to `when` for returning Promises

### DIFF
--- a/src/notify-js.js
+++ b/src/notify-js.js
@@ -106,11 +106,22 @@ function create(O) {'use strict';
     // invoke the callback with the resolved value
     when: function when(type,  callback) {
       var info = get(type);
-      if (info.args) {
+
+      // if no callback is supplied
+      // return an actual promise
+      if (Promise && !callback) {
+        var output = new Promise(function(resolve) {
+          callback = resolve;
+        });
+      }
+
+      else if (info.args) {
         callback.apply(null, info.args);
       } else if(indexOf.call(info.cb, callback) < 0) {
         info.cb.push(callback);
       }
+
+      return output;
     },
 
     // .about is an alias for .that


### PR DESCRIPTION
The rationale depends upon ES7's `async` / `await`. The logic is that callback scopes are extra painful when you're dealing with a series of events that might already have occurred, and being able to `await` a notification makes massive sense when it's possible that the code may execute directly (well, not completely, but you get the idea). Basically, you can write code as if the asynchronicity of the notification is immaterial.

``` javascript
// Currently
notify.when( 'authenticated', userProfile =>
    // ...App logic
)

// My proposal: overload `when` to return an actual promise when no callback is provided
// Ugly monkey-patch version:
notify.when = ( type, callback ) =>
    callback
        ? when( type, callback )
        : new Promise( success =>
            when( type, success )
        )

// Using current environments, usage would just add extra cruft and cognitive noise 
// Extra confusing "hang on how promise-like is this?"
notify.when( 'authenticated' ).then( userProfile => {
    // ...App logic
} )

// But in ES7, this becomes awesome because you can flatten the whole thing to better reflect the sequential model
const userProfile = await notify.when( 'authenticated' )

// ...App logic
```
